### PR TITLE
RFC0003 - Unconditional jumps are expressions, unreachable type

### DIFF
--- a/Specification/ControlFlow.md
+++ b/Specification/ControlFlow.md
@@ -54,7 +54,7 @@ func main(): int {
 
 ## Return
 
-Return is an expression that evaluates to the `never` type.
+Return is an expression that evaluates to the `unreachable` type.
 
 ### Syntax
 
@@ -72,7 +72,7 @@ Return terminates the currently executed function and returns the value specifie
 
 ### Usage in expressions
 
-The rationale behind `return` being an expression with the `never` type is to be able to terminate computations early, while not tripping up type checking:
+The rationale behind `return` being an expression with the `unreachable` type is to be able to terminate computations early, while not tripping up type checking:
 
 ```cs
 // If return was a statement, there would be an error here, saying that the 'else' branch has type 'unit', but the other branch has type 'int32'
@@ -81,7 +81,7 @@ var x = if (y % 2 == 0) y / 2 else return;
 
 ## Goto
 
-Goto is an expression that evaluates to the `never` type. Labels are statements (or rather, declarations).
+Goto is an expression that evaluates to the `unreachable` type. Labels are statements (or rather, declarations).
 
 ### Syntax
 

--- a/Specification/ControlFlow.md
+++ b/Specification/ControlFlow.md
@@ -99,7 +99,7 @@ goto label_name
 
 ### Semantics
 
-Executing a `goto` means jumping the execution to the specified label. The jump can not jump into or our of the containing function (not even into contained or container functions).
+Executing a `goto` means jumping the execution to the specified label. The jump can not jump into or out of the containing function (not even into contained or container functions).
 
 ### Usage in expressions
 

--- a/Specification/ControlFlow.md
+++ b/Specification/ControlFlow.md
@@ -54,25 +54,34 @@ func main(): int {
 
 ## Return
 
-Return is a statement.
+Return is an expression that evaluates to the `never` type.
 
 ### Syntax
 
-Return is a statement, with an optional expression to return:
+Return has two syntax variants, with an optional expression to return:
 
 ```swift
-return; // unit return value
+return // unit return value
 
-return expr; // some evaluated expression return value
+return expr // some evaluated expression return value
 ```
 
 ### Semantics
 
-Return terminates the currently executed function and returns the value specified (or unit, if none was specified). If a return statement is omitted from a block-syntax function, it is assumed to return unit at the very end.
+Return terminates the currently executed function and returns the value specified (or unit, if none was specified). If a return expression is omitted from a block-syntax function, it is assumed to return `unit` at the very end.
+
+### Usage in expressions
+
+The rationale behind `return` being an expression with the `never` type is to be able to terminate computations early, while not tripping up type checking:
+
+```cs
+// If return was a statement, there would be an error here, saying that the 'else' branch has type 'unit', but the other branch has type 'int32'
+var x = if (y % 2 == 0) y / 2 else return;
+```
 
 ## Goto
 
-Goto is a statement. Labels are statements (or rather, declarations).
+Goto is an expression that evaluates to the `never` type. Labels are statements (or rather, declarations).
 
 ### Syntax
 
@@ -82,15 +91,26 @@ The syntax for a labels is:
 label_name:
 ```
 
-The syntax of a goto statement is:
+The syntax of a goto expression is:
 
 ```cs
-goto label_name;
+goto label_name
 ```
 
 ### Semantics
 
-Executing a `goto` statement means jumping the execution to the specified label. The jump can not jump into or our of the containing function (not even into contained or container functions).
+Executing a `goto` means jumping the execution to the specified label. The jump can not jump into or our of the containing function (not even into contained or container functions).
+
+### Usage in expressions
+
+The rationale behind it being an expression is similar to the return expression:
+
+```cs
+retry:
+    n = n / 2;
+    x += 1;
+    var mustBeZero = if (n == 0) x else goto retry;
+```
 
 ## Code blocks
 

--- a/Specification/ExpressionsAndBuiltins.md
+++ b/Specification/ExpressionsAndBuiltins.md
@@ -35,6 +35,7 @@ The following primitive types are supported:
  * `float32`
  * `float64`
  * `unit`, which is roughly equivalent to the `void` type in C#, but is a true type in the type system, not a marker for no-return (meaning that you can for example use it as a generic parameter, or create a variable of type `unit`)
+ * `never`, which is a type of all expressions that take away the execution control from the evaluated expression. This is the type of all unconditional jumps. `never` is always implicitly convertible to other types.
 
 The naming of these types gets rid of the C heritage, which is very inconsistent among the C family. The slight inconsistency of `byte` and `sbyte` is also removed. The explicit sizes make sure we don't look up docs to know integer sizes.
 

--- a/Specification/ExpressionsAndBuiltins.md
+++ b/Specification/ExpressionsAndBuiltins.md
@@ -35,7 +35,7 @@ The following primitive types are supported:
  * `float32`
  * `float64`
  * `unit`, which is roughly equivalent to the `void` type in C#, but is a true type in the type system, not a marker for no-return (meaning that you can for example use it as a generic parameter, or create a variable of type `unit`)
- * `never`, which is a type of all expressions that take away the execution control from the evaluated expression. This is the type of all unconditional jumps. `never` is always implicitly convertible to other types.
+ * `unreachable`, which is a type of all expressions that take away the execution control from the evaluated expression. This is the type of all unconditional jumps. `unreachable` is always implicitly convertible to other types.
 
 The naming of these types gets rid of the C heritage, which is very inconsistent among the C family. The slight inconsistency of `byte` and `sbyte` is also removed. The explicit sizes make sure we don't look up docs to know integer sizes.
 


### PR DESCRIPTION
This RFC modifies the unconditional jump statements to be expressions. This is to aid situations where the expression is terminated early without needing to wrap the `return`/`goto`/`throw` statements into an expression block with phony values.